### PR TITLE
feat: Support v2 storage and send notification for each token

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ where usrname='hemlock' and s.name='hemlock.push_notification_data';
 (1 row)
 ```
 
+NOTE: As of v2, the token may be a bare token or a base64url-encoded set of tokens.  If the value starts with "eyJl"
+it is likely base64url-encoded.  You can decode and pretty-print the contents with this command:
+```bash
+echo "$token" | basenc --base64url -d | jq .
+```
+
 Collecting Metrics
 ------------------
 GET /metrics

--- a/buildinfo.go
+++ b/buildinfo.go
@@ -30,7 +30,10 @@ func readBuildInfo() (string, error) {
 	}
 	programName := filepath.Base(execPath)
 
-	if builtBy != "goreleaser" {
+	if builtBy == "goreleaser" {
+		commit = safeSubstr(commit, 8)
+		date = safeSubstr(date, 10)
+	} else {
 		info, ok := debug.ReadBuildInfo()
 		if !ok {
 			return "", fmt.Errorf("ReadBuildInfo failed")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module kenstir.net/hemlock-sendmsg
+module github.com/kenstir/hemlock-sendmsg
 
 go 1.22.2
 
@@ -7,6 +7,8 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	google.golang.org/api v0.170.0
 )
+
+require github.com/google/go-cmp v0.6.0
 
 require (
 	cloud.google.com/go v0.112.1 // indirect

--- a/sendmsg.go
+++ b/sendmsg.go
@@ -25,6 +25,9 @@ import (
 const HemlockNotificationTypeKey = "hemlock.t"
 const HemlockNotificationUsernameKey = "hemlock.u"
 
+// Cutoff time for tokens; if a token was added before this time, we consider it expired
+const TokenExpirationCutoff = 365 * 24 * time.Hour
+
 // NB: This list of notification types (Android notification channelIds) must be kept in sync in 3 places:
 // * hemlock (android): core/src/main/java/org/evergreen_ils/data/PushNotification.kt
 // * hemlock-ios:       Source/Models/PushNotification.swift
@@ -86,7 +89,7 @@ func (srv *ServiceData) resultAndCodeFromError(err error) (result string, httpSt
 func (srv *ServiceData) sendMessage(entry TokenEntry, title string, body string, notificationType string, username string) (string, string, int, error) {
 	response := ""
 	var err error = nil
-	cutoff := time.Now().UTC().Add(-365 * 24 * time.Hour)
+	cutoff := time.Now().UTC().Add(-TokenExpirationCutoff)
 	if entry.Token == "" {
 		err = ErrEmptyToken
 	} else if entry.AddedAt.Before(cutoff) {

--- a/sendmsg.go
+++ b/sendmsg.go
@@ -140,8 +140,8 @@ func (srv *ServiceData) sendHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// tokenData is "required", but we don't report it as an error because we want to
-	// track EmptyToken requests, i.e. for users without the mobile apps
+	// tokenData is "required", but we don't require it because we want to track
+	// EmptyToken requests, i.e. notifications for users without the mobile app
 	tokenData := r.FormValue("token")
 
 	// should be required

--- a/sendmsg.go
+++ b/sendmsg.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -48,39 +49,41 @@ type ServiceData struct {
 }
 
 // determine the HTTP status code for the response, and a result label for the measurement
-func (srv *ServiceData) sendMessageResult(err error) (result string, httpStatusCode int) {
+func (srv *ServiceData) resultAndCodeFromError(err error) (result string, httpStatusCode int) {
+	// handle local errors
 	if err == nil {
-		httpStatusCode = http.StatusOK
-		result = "ok"
-	} else if err == ErrEmptyToken {
-		httpStatusCode = http.StatusBadRequest
-		result = "EmptyToken"
-	} else if err != nil {
-		httpStatusCode = http.StatusInternalServerError
-		if resp := errorutils.HTTPResponse(err); resp != nil {
-			httpStatusCode = resp.StatusCode
-		}
-		result = ""
-		if messaging.IsUnregistered(err) {
-			result = "Unregistered"
-			// should remove token from db
-		} else if errorutils.IsUnavailable(err) {
-			result = "Unavailable"
-			// should retry in an hour
-		} else if messaging.IsInternal(err) {
-			result = "InternalError"
-		} else if messaging.IsInvalidArgument(err) {
-			result = "InvalidArgument"
-		} else {
-			result = "UnknownError"
-		}
+		return "ok", http.StatusOK
+	} else if errors.Is(err, ErrEmptyToken) {
+		return "EmptyToken", http.StatusBadRequest
+	} else if errors.Is(err, ErrExpiredToken) {
+		return "ExpiredToken", http.StatusBadRequest
+	}
+
+	// it's an FCM error; use the FCM response status code if available
+	httpStatusCode = http.StatusInternalServerError
+	if resp := errorutils.HTTPResponse(err); resp != nil {
+		httpStatusCode = resp.StatusCode
+	}
+
+	// determine appropriate result label for metrics
+	if messaging.IsUnregistered(err) {
+		result = "Unregistered"
+		// should remove token from db
+	} else if errorutils.IsUnavailable(err) {
+		result = "Unavailable"
+		// should retry in an hour
+	} else if messaging.IsInternal(err) {
+		result = "InternalError"
+	} else if messaging.IsInvalidArgument(err) {
+		result = "InvalidArgument"
+	} else {
+		result = "UnknownError"
 	}
 	return result, httpStatusCode
 }
 
-// send a notification
+// send one notification
 func (srv *ServiceData) sendMessage(entry TokenEntry, title string, body string, notificationType string, username string) (string, string, int, error) {
-	// send the message
 	response := ""
 	var err error = nil
 	cutoff := time.Now().UTC().Add(-365 * 24 * time.Hour)
@@ -106,7 +109,7 @@ func (srv *ServiceData) sendMessage(entry TokenEntry, title string, body string,
 			Token: entry.Token,
 		})
 	}
-	result, httpStatusCode := srv.sendMessageResult(err)
+	result, httpStatusCode := srv.resultAndCodeFromError(err)
 	srv.notificationsSent.WithLabelValues(result).Inc()
 	return response, result, httpStatusCode, err
 }
@@ -180,7 +183,9 @@ func (srv *ServiceData) sendHandler(w http.ResponseWriter, r *http.Request) {
 		} else {
 			fmt.Fprintf(w, "%s\n", response)
 		}
-		slog.Log(r.Context(), logLevel, fmt.Sprintf("%s %s", r.Method, r.URL.Path), "result", result, "code", httpStatusCode, "username", username, "title", title, "type", notificationType, "body", body, "token", entry.Token)
+		slog.Log(r.Context(), logLevel, fmt.Sprintf("%s %s", r.Method, r.URL.Path),
+			"result", result, "code", httpStatusCode, "username", username,
+			"title", title, "type", notificationType, "body", body, "token", entry.Token)
 	}
 }
 

--- a/sendmsg.go
+++ b/sendmsg.go
@@ -89,10 +89,10 @@ func (srv *ServiceData) resultAndCodeFromError(err error) (result string, httpSt
 func (srv *ServiceData) sendMessage(entry TokenEntry, title string, body string, notificationType string, username string) (string, string, int, error) {
 	response := ""
 	var err error = nil
-	cutoff := time.Now().UTC().Add(-TokenExpirationCutoff)
+	cutoff := time.Now().UTC().Add(-TokenExpirationCutoff).Unix()
 	if entry.Token == "" {
 		err = ErrEmptyToken
-	} else if entry.AddedAt.Before(cutoff) {
+	} else if entry.AddedAt < cutoff {
 		err = ErrExpiredToken
 	} else {
 		response, err = srv.fcmClient.Send(context.Background(), &messaging.Message{

--- a/sendmsg.go
+++ b/sendmsg.go
@@ -177,19 +177,30 @@ func (srv *ServiceData) sendHandler(w http.ResponseWriter, r *http.Request) {
 	tokenStore := NewTokenStoreFromString(tokenData)
 
 	// send a message for each token
+	var responseBody strings.Builder
+	hasError := false
+	errorStatusCode := http.StatusInternalServerError
 	for _, entry := range tokenStore.Entries {
 		response, result, httpStatusCode, err := srv.sendMessage(entry, title, body, notificationType, username)
 		if err != nil {
 			slog.Error("Failed to send notification", "result", result, "code", httpStatusCode, "err", err)
-			w.WriteHeader(httpStatusCode)
-			fmt.Fprintf(w, "%s\n", err.Error())
+			if !hasError {
+				hasError = true
+				errorStatusCode = httpStatusCode
+			}
+			fmt.Fprintf(&responseBody, "%s\n", err.Error())
 		} else {
-			fmt.Fprintf(w, "%s\n", response)
+			fmt.Fprintf(&responseBody, "%s\n", response)
 		}
 		slog.Log(r.Context(), logLevel, fmt.Sprintf("%s %s", r.Method, r.URL.Path),
 			"result", result, "code", httpStatusCode, "username", username,
 			"title", title, "type", notificationType, "body", body, "token", entry.Token)
 	}
+
+	if hasError {
+		w.WriteHeader(errorStatusCode)
+	}
+	fmt.Fprint(w, responseBody.String())
 }
 
 func createServiceData(credentialsFile string) (*ServiceData, error) {

--- a/sendmsg.go
+++ b/sendmsg.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	firebase "firebase.google.com/go/v4"
 	"firebase.google.com/go/v4/errorutils"
@@ -35,17 +36,23 @@ var HemlockNotificationTypes = map[string]bool{
 	"pmc":       true,
 }
 
+var (
+	ErrEmptyToken   = fmt.Errorf("empty token")
+	ErrExpiredToken = fmt.Errorf("token too old")
+)
+
 type ServiceData struct {
 	fcmClient *messaging.Client
 
 	notificationsSent *prometheus.CounterVec
 }
 
-// categorize the result of sendMessage and record metric
-func (srv *ServiceData) trackSendMessage(token string, err error) (string, int) {
-	httpStatusCode := http.StatusOK
-	result := "ok"
-	if token == "" {
+// determine the HTTP status code for the response, and a result label for the measurement
+func (srv *ServiceData) sendMessageResult(err error) (result string, httpStatusCode int) {
+	if err == nil {
+		httpStatusCode = http.StatusOK
+		result = "ok"
+	} else if err == ErrEmptyToken {
 		httpStatusCode = http.StatusBadRequest
 		result = "EmptyToken"
 	} else if err != nil {
@@ -68,16 +75,20 @@ func (srv *ServiceData) trackSendMessage(token string, err error) (string, int) 
 			result = "UnknownError"
 		}
 	}
-	srv.notificationsSent.WithLabelValues(result).Inc()
 	return result, httpStatusCode
 }
 
 // send a notification
-func (srv *ServiceData) sendMessage(token string, title string, body string, notificationType string, username string) (string, string, int, error) {
+func (srv *ServiceData) sendMessage(entry TokenEntry, title string, body string, notificationType string, username string) (string, string, int, error) {
 	// send the message
 	response := ""
 	var err error = nil
-	if token != "" {
+	cutoff := time.Now().UTC().Add(-365 * 24 * time.Hour)
+	if entry.Token == "" {
+		err = ErrEmptyToken
+	} else if entry.AddedAt.Before(cutoff) {
+		err = ErrExpiredToken
+	} else {
 		response, err = srv.fcmClient.Send(context.Background(), &messaging.Message{
 			Data: map[string]string{
 				HemlockNotificationTypeKey:     notificationType,
@@ -92,10 +103,11 @@ func (srv *ServiceData) sendMessage(token string, title string, body string, not
 					ChannelID: notificationType,
 				},
 			},
-			Token: token,
+			Token: entry.Token,
 		})
 	}
-	result, httpStatusCode := srv.trackSendMessage(token, err)
+	result, httpStatusCode := srv.sendMessageResult(err)
+	srv.notificationsSent.WithLabelValues(result).Inc()
 	return response, result, httpStatusCode, err
 }
 
@@ -122,9 +134,9 @@ func (srv *ServiceData) sendHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// token is "required", but we want to keep track of requests made without one,
-	// to count users without the mobile app
-	token := r.FormValue("token")
+	// tokenData is "required", but we don't report it as an error because we want to
+	// track EmptyToken requests, i.e. for users without the mobile apps
+	tokenData := r.FormValue("token")
 
 	// should be required
 	username := r.FormValue("username")
@@ -155,16 +167,21 @@ func (srv *ServiceData) sendHandler(w http.ResponseWriter, r *http.Request) {
 		logLevel = slog.LevelInfo
 	}
 
-	// send the message
-	response, result, httpStatusCode, err := srv.sendMessage(token, title, body, notificationType, username)
-	if err != nil {
-		slog.Error("Failed to send notification", "result", result, "code", httpStatusCode, "err", err)
-		w.WriteHeader(httpStatusCode)
-		fmt.Fprintf(w, "%s\n", err.Error())
-	} else {
-		fmt.Fprintf(w, "%s\n", response)
+	// v2: handle either a single token or a JSON object with multiple tokens
+	tokenStore := NewTokenStoreFromString(tokenData)
+
+	// send a message for each token
+	for _, entry := range tokenStore.Entries {
+		response, result, httpStatusCode, err := srv.sendMessage(entry, title, body, notificationType, username)
+		if err != nil {
+			slog.Error("Failed to send notification", "result", result, "code", httpStatusCode, "err", err)
+			w.WriteHeader(httpStatusCode)
+			fmt.Fprintf(w, "%s\n", err.Error())
+		} else {
+			fmt.Fprintf(w, "%s\n", response)
+		}
+		slog.Log(r.Context(), logLevel, fmt.Sprintf("%s %s", r.Method, r.URL.Path), "result", result, "code", httpStatusCode, "username", username, "title", title, "type", notificationType, "body", body, "token", entry.Token)
 	}
-	slog.Log(r.Context(), logLevel, fmt.Sprintf("%s %s", r.Method, r.URL.Path), "result", result, "code", httpStatusCode, "username", username, "title", title, "type", notificationType, "body", body, "token", token)
 }
 
 func createServiceData(credentialsFile string) (*ServiceData, error) {

--- a/token_store.go
+++ b/token_store.go
@@ -9,6 +9,10 @@ import (
 
 const MaxEntries = 3
 
+// decoder/encoder for v2 tokens, declared here so they can be tested as compatible
+var V2DecodeString = base64.RawURLEncoding.DecodeString
+var V2EncodeString = base64.RawURLEncoding.EncodeToString
+
 // prefix on all v2 base64url-encoded tokens, which when decoded is `{"entries":[`
 const V2EncodedTokenPrefix = "eyJlbnRyaWVzIjpb"
 
@@ -68,7 +72,7 @@ func (ts *TokenStore) FromJSON(data []byte) error {
 func (ts *TokenStore) FromString(str string) {
 	// if it looks like a v2 encoded object, try to parse it
 	if strings.HasPrefix(str, V2EncodedTokenPrefix) {
-		decoded, err := base64.RawURLEncoding.DecodeString(str)
+		decoded, err := V2DecodeString(str)
 		if err == nil {
 			err = ts.FromJSON(decoded)
 			if err == nil {

--- a/token_store.go
+++ b/token_store.go
@@ -9,12 +9,12 @@ import (
 const MaxEntries = 3
 
 type TokenEntry struct {
-	Token   string    `json:"tok"`
+	Token   string    `json:"token"`
 	AddedAt time.Time `json:"added_at"`
 }
 
 type TokenStore struct {
-	Entries []TokenEntry `json:"tokens"`
+	Entries []TokenEntry `json:"entries"`
 }
 
 func NewTokenStore() *TokenStore {

--- a/token_store.go
+++ b/token_store.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 )
 
@@ -20,6 +21,12 @@ func NewTokenStore() *TokenStore {
 	return &TokenStore{
 		Entries: make([]TokenEntry, 0, MaxEntries),
 	}
+}
+
+func NewTokenStoreFromString(str string) *TokenStore {
+	ts := NewTokenStore()
+	ts.FromString(str)
+	return ts
 }
 
 func (cm *TokenStore) AddToken(token string) {
@@ -51,4 +58,18 @@ func (cm *TokenStore) ToJSON() ([]byte, error) {
 
 func (cm *TokenStore) FromJSON(data []byte) error {
 	return json.Unmarshal(data, cm)
+}
+
+// FromString creates a TokenStore from a string, which might be a single string token or a JSON object.
+func (cm *TokenStore) FromString(str string) {
+	// if it looks like a JSON object, try to parse it
+	if strings.HasPrefix(str, "{") && strings.HasSuffix(str, "}") {
+		err := cm.FromJSON([]byte(str))
+		if err == nil {
+			return
+		}
+	}
+
+	// treat it as a single token string
+	cm.AddToken(str)
 }

--- a/token_store.go
+++ b/token_store.go
@@ -68,7 +68,7 @@ func (ts *TokenStore) FromJSON(data []byte) error {
 func (ts *TokenStore) FromString(str string) {
 	// if it looks like a v2 encoded object, try to parse it
 	if strings.HasPrefix(str, V2EncodedTokenPrefix) {
-		decoded, err := base64.URLEncoding.DecodeString(str)
+		decoded, err := base64.RawURLEncoding.DecodeString(str)
 		if err == nil {
 			err = ts.FromJSON(decoded)
 			if err == nil {

--- a/token_store.go
+++ b/token_store.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"time"
 )
 
 const MaxEntries = 3
+
+// prefix for all v2 encoded tokens, base64url-encoded string '{"entries":['
+const V2EncodedTokenPrefix = "eyJlbnRyaWVzIjpb"
 
 type TokenEntry struct {
 	Token   string `json:"token"`
@@ -29,48 +33,50 @@ func NewTokenStoreFromString(str string) *TokenStore {
 	return ts
 }
 
-func (cm *TokenStore) AddToken(token string) {
-	cm.AddTokenEntry(TokenEntry{
+func (ts *TokenStore) AddToken(token string) {
+	ts.AddTokenEntry(TokenEntry{
 		Token:   token,
 		AddedAt: time.Now().Unix(),
 	})
 }
 
-func (cm *TokenStore) AddTokenEntry(entry TokenEntry) {
-	if len(cm.Entries) >= MaxEntries {
-		cm.Entries = cm.Entries[1:]
+func (ts *TokenStore) AddTokenEntry(entry TokenEntry) {
+	if len(ts.Entries) >= MaxEntries {
+		ts.Entries = ts.Entries[1:]
 	}
-	cm.Entries = append(cm.Entries, entry)
+	ts.Entries = append(ts.Entries, entry)
 }
 
-func (cm *TokenStore) FindToken(token string) *TokenEntry {
-	for i := len(cm.Entries) - 1; i >= 0; i-- {
-		if cm.Entries[i].Token == token {
-			return &cm.Entries[i]
+func (ts *TokenStore) FindToken(token string) *TokenEntry {
+	for i := len(ts.Entries) - 1; i >= 0; i-- {
+		if ts.Entries[i].Token == token {
+			return &ts.Entries[i]
 		}
 	}
 	return nil
 }
 
-func (cm *TokenStore) ToJSON() ([]byte, error) {
-	return json.Marshal(cm)
+func (ts *TokenStore) ToJSON() ([]byte, error) {
+	return json.Marshal(ts)
 }
 
-func (cm *TokenStore) FromJSON(data []byte) error {
-	return json.Unmarshal(data, cm)
+func (ts *TokenStore) FromJSON(data []byte) error {
+	return json.Unmarshal(data, ts)
 }
 
-// FromString creates a TokenStore from a string, which might be a single string token or a JSON object.
-func (cm *TokenStore) FromString(str string) {
-	// if it looks like a JSON object, try to parse it
-	trimmed := strings.TrimSpace(str)
-	if strings.HasPrefix(trimmed, "{") && strings.HasSuffix(trimmed, "}") {
-		err := cm.FromJSON([]byte(trimmed))
+// FromString creates a TokenStore from a string, either a plain PN token (v1) or a base64url-encoded JSON TS object (v2).
+func (ts *TokenStore) FromString(str string) {
+	// if it looks like a v2 encoded object, try to parse it
+	if strings.HasPrefix(str, V2EncodedTokenPrefix) {
+		decoded, err := base64.URLEncoding.DecodeString(str)
 		if err == nil {
-			return
+			err = ts.FromJSON(decoded)
+			if err == nil {
+				return
+			}
 		}
 	}
 
 	// treat it as a single token string
-	cm.AddToken(str)
+	ts.AddToken(str)
 }

--- a/token_store.go
+++ b/token_store.go
@@ -9,7 +9,7 @@ import (
 
 const MaxEntries = 3
 
-// prefix for all v2 encoded tokens, base64url-encoded string '{"entries":['
+// prefix on all v2 base64url-encoded tokens, which when decoded is `{"entries":[`
 const V2EncodedTokenPrefix = "eyJlbnRyaWVzIjpb"
 
 type TokenEntry struct {

--- a/token_store.go
+++ b/token_store.go
@@ -63,8 +63,9 @@ func (cm *TokenStore) FromJSON(data []byte) error {
 // FromString creates a TokenStore from a string, which might be a single string token or a JSON object.
 func (cm *TokenStore) FromString(str string) {
 	// if it looks like a JSON object, try to parse it
-	if strings.HasPrefix(str, "{") && strings.HasSuffix(str, "}") {
-		err := cm.FromJSON([]byte(str))
+	trimmed := strings.TrimSpace(str)
+	if strings.HasPrefix(trimmed, "{") && strings.HasSuffix(trimmed, "}") {
+		err := cm.FromJSON([]byte(trimmed))
 		if err == nil {
 			return
 		}

--- a/token_store.go
+++ b/token_store.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const MaxEntries = 3
+
+type TokenEntry struct {
+	Token   string    `json:"tok"`
+	AddedAt time.Time `json:"added_at"`
+}
+
+type TokenStore struct {
+	Entries []TokenEntry `json:"tokens"`
+}
+
+func NewTokenStore() *TokenStore {
+	return &TokenStore{
+		Entries: make([]TokenEntry, 0, MaxEntries),
+	}
+}
+
+func (cm *TokenStore) AddToken(token string) {
+	cm.AddTokenEntry(TokenEntry{
+		Token:   token,
+		AddedAt: time.Now().UTC().Truncate(time.Second),
+	})
+}
+
+func (cm *TokenStore) AddTokenEntry(entry TokenEntry) {
+	if len(cm.Entries) >= MaxEntries {
+		cm.Entries = cm.Entries[1:]
+	}
+	cm.Entries = append(cm.Entries, entry)
+}
+
+func (cm *TokenStore) FindToken(token string) *TokenEntry {
+	for i := len(cm.Entries) - 1; i >= 0; i-- {
+		if cm.Entries[i].Token == token {
+			return &cm.Entries[i]
+		}
+	}
+	return nil
+}
+
+func (cm *TokenStore) ToJSON() ([]byte, error) {
+	return json.Marshal(cm)
+}
+
+func (cm *TokenStore) FromJSON(data []byte) error {
+	return json.Unmarshal(data, cm)
+}

--- a/token_store.go
+++ b/token_store.go
@@ -9,8 +9,8 @@ import (
 const MaxEntries = 3
 
 type TokenEntry struct {
-	Token   string    `json:"token"`
-	AddedAt time.Time `json:"added_at"`
+	Token   string `json:"token"`
+	AddedAt int64  `json:"added_at"`
 }
 
 type TokenStore struct {
@@ -32,7 +32,7 @@ func NewTokenStoreFromString(str string) *TokenStore {
 func (cm *TokenStore) AddToken(token string) {
 	cm.AddTokenEntry(TokenEntry{
 		Token:   token,
-		AddedAt: time.Now().UTC().Truncate(time.Second),
+		AddedAt: time.Now().Unix(),
 	})
 }
 

--- a/token_store_test.go
+++ b/token_store_test.go
@@ -109,3 +109,44 @@ func TestFromJSONInvalid(t *testing.T) {
 		t.Fatal("expected error for invalid JSON")
 	}
 }
+
+func TestFromStringSingleToken(t *testing.T) {
+	ts := NewTokenStoreFromString("token-1")
+	want := 1
+	got := len(ts.Entries)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got): %s", diff)
+	}
+}
+
+func TestFromStringJSONSingleToken(t *testing.T) {
+	ts := NewTokenStoreFromString(`{"tokens":[{"tok":"token-1","added_at":"2026-04-09T13:15:00Z"}]}`)
+	want := 1
+	got := len(ts.Entries)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got): %s", diff)
+	}
+}
+
+func TestFromStringJSONMultipleTokens(t *testing.T) {
+	ts := NewTokenStoreFromString(`{"tokens":[{"tok":"token-1","added_at":"2026-04-08T13:15:00Z"},{"tok":"token-2","added_at":"2026-04-09T13:16:00Z"}]}`)
+	want := 2
+	got := len(ts.Entries)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got): %s", diff)
+	}
+}
+
+func TestFromStringThatLooksLikeJSON(t *testing.T) {
+	ts := NewTokenStoreFromString("{xyzzy}")
+	want := 1
+	got := len(ts.Entries)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got): %s", diff)
+	}
+	token := ts.Entries[0].Token
+	wantToken := "{xyzzy}"
+	if diff := cmp.Diff(wantToken, token); diff != "" {
+		t.Errorf("mismatch (-want +got): %s", diff)
+	}
+}

--- a/token_store_test.go
+++ b/token_store_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -21,7 +22,7 @@ func TestAddToken(t *testing.T) {
 func TestAddTooManyTokens(t *testing.T) {
 	ts := NewTokenStore()
 	for i := 0; i <= MaxEntries+1; i++ {
-		ts.AddToken("token-" + string(rune(i)))
+		ts.AddToken(fmt.Sprintf("token-%d", i))
 	}
 
 	want := MaxEntries
@@ -31,13 +32,13 @@ func TestAddTooManyTokens(t *testing.T) {
 	}
 
 	firstToken := ts.Entries[0].Token
-	wantFirst := "token-" + string(rune(2))
+	wantFirst := "token-2"
 	if diff := cmp.Diff(wantFirst, firstToken); diff != "" {
 		t.Errorf("mismatch (-want +got): %s", diff)
 	}
 
 	lastToken := ts.Entries[len(ts.Entries)-1].Token
-	wantLast := "token-" + string(rune(MaxEntries+1))
+	wantLast := fmt.Sprintf("token-%d", MaxEntries+1)
 	if diff := cmp.Diff(wantLast, lastToken); diff != "" {
 		t.Errorf("mismatch (-want +got): %s", diff)
 	}

--- a/token_store_test.go
+++ b/token_store_test.go
@@ -12,6 +12,7 @@ func TestAddToken(t *testing.T) {
 	ts := NewTokenStore()
 	token := "test-token-1"
 	ts.AddToken(token)
+
 	want := 1
 	got := len(ts.Entries)
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -113,6 +114,7 @@ func TestFromJSONInvalid(t *testing.T) {
 
 func TestFromStringSingleToken(t *testing.T) {
 	ts := NewTokenStoreFromString("token-1")
+
 	want := 1
 	got := len(ts.Entries)
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -122,8 +124,9 @@ func TestFromStringSingleToken(t *testing.T) {
 
 func TestFromStringV2SingleToken(t *testing.T) {
 	json := `{"entries":[{"token":"token-1","added_at":1712664900}]}`
-	encoded := base64.URLEncoding.EncodeToString([]byte(json))
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(json))
 	ts := NewTokenStoreFromString(encoded)
+
 	want := 1
 	got := len(ts.Entries)
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -133,8 +136,9 @@ func TestFromStringV2SingleToken(t *testing.T) {
 
 func TestFromStringJSONMultipleTokens(t *testing.T) {
 	json := `{"entries":[{"token":"token-1","added_at":1712578500},{"token":"token-2","added_at":1712664960}]}`
-	encoded := base64.URLEncoding.EncodeToString([]byte(json))
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(json))
 	ts := NewTokenStoreFromString(encoded)
+
 	want := 2
 	got := len(ts.Entries)
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -145,6 +149,7 @@ func TestFromStringJSONMultipleTokens(t *testing.T) {
 func TestFromStringThatLooksLikeV2(t *testing.T) {
 	str := V2EncodedTokenPrefix + "xyzzy"
 	ts := NewTokenStoreFromString(str)
+
 	want := 1
 	got := len(ts.Entries)
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/token_store_test.go
+++ b/token_store_test.go
@@ -80,7 +80,7 @@ func TestToJSON(t *testing.T) {
 		t.Fatal("expected non-empty JSON")
 	}
 	got := string(data)
-	want := `{"tokens":[{"tok":"token-1","added_at":"2026-04-09T13:15:00Z"}]}`
+	want := `{"entries":[{"token":"token-1","added_at":"2026-04-09T13:15:00Z"}]}`
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got): %s", diff)
 	}
@@ -121,7 +121,7 @@ func TestFromStringSingleToken(t *testing.T) {
 }
 
 func TestFromStringJSONSingleToken(t *testing.T) {
-	ts := NewTokenStoreFromString(`{"tokens":[{"tok":"token-1","added_at":"2026-04-09T13:15:00Z"}]}`)
+	ts := NewTokenStoreFromString(`{"entries":[{"token":"token-1","added_at":"2026-04-09T13:15:00Z"}]}`)
 	want := 1
 	got := len(ts.Entries)
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -130,7 +130,7 @@ func TestFromStringJSONSingleToken(t *testing.T) {
 }
 
 func TestFromStringJSONMultipleTokens(t *testing.T) {
-	ts := NewTokenStoreFromString(`{"tokens":[{"tok":"token-1","added_at":"2026-04-08T13:15:00Z"},{"tok":"token-2","added_at":"2026-04-09T13:16:00Z"}]}`)
+	ts := NewTokenStoreFromString(`{"entries":[{"token":"token-1","added_at":"2026-04-08T13:15:00Z"},{"token":"token-2","added_at":"2026-04-09T13:16:00Z"}]}`)
 	want := 2
 	got := len(ts.Entries)
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/token_store_test.go
+++ b/token_store_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -69,7 +68,7 @@ func TestToJSON(t *testing.T) {
 	ts := NewTokenStore()
 	ts.AddTokenEntry(TokenEntry{
 		Token:   "token-1",
-		AddedAt: time.Date(2026, 4, 9, 13, 15, 0, 0, time.UTC),
+		AddedAt: 1712664900, // 2024-04-09T13:15:00Z
 	})
 
 	data, err := ts.ToJSON()
@@ -80,7 +79,7 @@ func TestToJSON(t *testing.T) {
 		t.Fatal("expected non-empty JSON")
 	}
 	got := string(data)
-	want := `{"entries":[{"token":"token-1","added_at":"2026-04-09T13:15:00Z"}]}`
+	want := `{"entries":[{"token":"token-1","added_at":1712664900}]}`
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got): %s", diff)
 	}
@@ -121,7 +120,7 @@ func TestFromStringSingleToken(t *testing.T) {
 }
 
 func TestFromStringJSONSingleToken(t *testing.T) {
-	ts := NewTokenStoreFromString(`{"entries":[{"token":"token-1","added_at":"2026-04-09T13:15:00Z"}]}`)
+	ts := NewTokenStoreFromString(`{"entries":[{"token":"token-1","added_at":1712664900}]}`)
 	want := 1
 	got := len(ts.Entries)
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -130,7 +129,7 @@ func TestFromStringJSONSingleToken(t *testing.T) {
 }
 
 func TestFromStringJSONMultipleTokens(t *testing.T) {
-	ts := NewTokenStoreFromString(`{"entries":[{"token":"token-1","added_at":"2026-04-08T13:15:00Z"},{"token":"token-2","added_at":"2026-04-09T13:16:00Z"}]}`)
+	ts := NewTokenStoreFromString(`{"entries":[{"token":"token-1","added_at":1712578500},{"token":"token-2","added_at":1712664960}]}`)
 	want := 2
 	got := len(ts.Entries)
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/token_store_test.go
+++ b/token_store_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAddToken(t *testing.T) {
+	ts := NewTokenStore()
+	token := "test-token-1"
+	ts.AddToken(token)
+	want := 1
+	got := len(ts.Entries)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got): %s", diff)
+	}
+}
+
+func TestAddTooManyTokens(t *testing.T) {
+	ts := NewTokenStore()
+	for i := 0; i <= MaxEntries+1; i++ {
+		ts.AddToken("token-" + string(rune(i)))
+	}
+
+	want := MaxEntries
+	got := len(ts.Entries)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got): %s", diff)
+	}
+
+	firstToken := ts.Entries[0].Token
+	wantFirst := "token-" + string(rune(2))
+	if diff := cmp.Diff(wantFirst, firstToken); diff != "" {
+		t.Errorf("mismatch (-want +got): %s", diff)
+	}
+
+	lastToken := ts.Entries[len(ts.Entries)-1].Token
+	wantLast := "token-" + string(rune(MaxEntries+1))
+	if diff := cmp.Diff(wantLast, lastToken); diff != "" {
+		t.Errorf("mismatch (-want +got): %s", diff)
+	}
+}
+
+func TestFindToken(t *testing.T) {
+	ts := NewTokenStore()
+	ts.AddToken("token-1")
+	ts.AddToken("token-2")
+
+	found := ts.FindToken("token-2")
+	if diff := cmp.Diff("token-2", found.Token); diff != "" {
+		t.Errorf("mismatch (-want +got): %s", diff)
+	}
+}
+
+func TestFindTokenNotFound(t *testing.T) {
+	ts := NewTokenStore()
+	ts.AddToken("token-1")
+
+	found := ts.FindToken("nonexistent")
+	if found != nil {
+		t.Errorf("expected nil, got %v", found)
+	}
+}
+
+func TestToJSON(t *testing.T) {
+	ts := NewTokenStore()
+	ts.AddTokenEntry(TokenEntry{
+		Token:   "token-1",
+		AddedAt: time.Date(2026, 4, 9, 13, 15, 0, 0, time.UTC),
+	})
+
+	data, err := ts.ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected non-empty JSON")
+	}
+	got := string(data)
+	want := `{"tokens":[{"tok":"token-1","added_at":"2026-04-09T13:15:00Z"}]}`
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got): %s", diff)
+	}
+}
+
+func TestFromJSON(t *testing.T) {
+	original := NewTokenStore()
+	original.AddToken("token-1")
+	original.AddToken("token-2")
+
+	data, _ := original.ToJSON()
+
+	ts := NewTokenStore()
+	err := ts.FromJSON(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ts.Entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(ts.Entries))
+	}
+}
+
+func TestFromJSONInvalid(t *testing.T) {
+	ts := NewTokenStore()
+	err := ts.FromJSON([]byte("invalid json"))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}

--- a/token_store_test.go
+++ b/token_store_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"fmt"
 	"testing"
 
@@ -119,8 +120,10 @@ func TestFromStringSingleToken(t *testing.T) {
 	}
 }
 
-func TestFromStringJSONSingleToken(t *testing.T) {
-	ts := NewTokenStoreFromString(`{"entries":[{"token":"token-1","added_at":1712664900}]}`)
+func TestFromStringV2SingleToken(t *testing.T) {
+	json := `{"entries":[{"token":"token-1","added_at":1712664900}]}`
+	encoded := base64.URLEncoding.EncodeToString([]byte(json))
+	ts := NewTokenStoreFromString(encoded)
 	want := 1
 	got := len(ts.Entries)
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -129,7 +132,9 @@ func TestFromStringJSONSingleToken(t *testing.T) {
 }
 
 func TestFromStringJSONMultipleTokens(t *testing.T) {
-	ts := NewTokenStoreFromString(`{"entries":[{"token":"token-1","added_at":1712578500},{"token":"token-2","added_at":1712664960}]}`)
+	json := `{"entries":[{"token":"token-1","added_at":1712578500},{"token":"token-2","added_at":1712664960}]}`
+	encoded := base64.URLEncoding.EncodeToString([]byte(json))
+	ts := NewTokenStoreFromString(encoded)
 	want := 2
 	got := len(ts.Entries)
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -137,16 +142,16 @@ func TestFromStringJSONMultipleTokens(t *testing.T) {
 	}
 }
 
-func TestFromStringThatLooksLikeJSON(t *testing.T) {
-	ts := NewTokenStoreFromString("{xyzzy}")
+func TestFromStringThatLooksLikeV2(t *testing.T) {
+	str := V2EncodedTokenPrefix + "xyzzy"
+	ts := NewTokenStoreFromString(str)
 	want := 1
 	got := len(ts.Entries)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch (-want +got): %s", diff)
 	}
 	token := ts.Entries[0].Token
-	wantToken := "{xyzzy}"
-	if diff := cmp.Diff(wantToken, token); diff != "" {
+	if diff := cmp.Diff(str, token); diff != "" {
 		t.Errorf("mismatch (-want +got): %s", diff)
 	}
 }

--- a/token_store_test.go
+++ b/token_store_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/base64"
 	"fmt"
 	"testing"
 
@@ -70,15 +69,12 @@ func TestToJSON(t *testing.T) {
 	ts := NewTokenStore()
 	ts.AddTokenEntry(TokenEntry{
 		Token:   "token-1",
-		AddedAt: 1712664900, // 2024-04-09T13:15:00Z
+		AddedAt: 1712664900,
 	})
 
 	data, err := ts.ToJSON()
 	if err != nil {
 		t.Fatal(err)
-	}
-	if len(data) == 0 {
-		t.Fatal("expected non-empty JSON")
 	}
 	got := string(data)
 	want := `{"entries":[{"token":"token-1","added_at":1712664900}]}`
@@ -122,9 +118,29 @@ func TestFromStringSingleToken(t *testing.T) {
 	}
 }
 
+func TestEncodingIsCompatible(t *testing.T) {
+	// Check that the implementation we are using is compatible with other implementations,
+	// that is, base64-url-encoding with no padding.
+	json := `{"a":"??~"}`
+	want := "eyJhIjoiPz9-In0" // plain base64 would be "eyJhIjoiPz9+In0="
+
+	encoded := V2EncodeString([]byte(json))
+	if diff := cmp.Diff(want, encoded); diff != "" {
+		t.Errorf("mismatch (-want +got): %s", diff)
+	}
+
+	decoded, err := V2DecodeString(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(json, string(decoded)); diff != "" {
+		t.Errorf("mismatch (-want +got): %s", diff)
+	}
+}
+
 func TestFromStringV2SingleToken(t *testing.T) {
 	json := `{"entries":[{"token":"token-1","added_at":1712664900}]}`
-	encoded := base64.RawURLEncoding.EncodeToString([]byte(json))
+	encoded := V2EncodeString([]byte(json))
 	ts := NewTokenStoreFromString(encoded)
 
 	want := 1
@@ -134,9 +150,9 @@ func TestFromStringV2SingleToken(t *testing.T) {
 	}
 }
 
-func TestFromStringJSONMultipleTokens(t *testing.T) {
+func TestFromStringV2MultipleTokens(t *testing.T) {
 	json := `{"entries":[{"token":"token-1","added_at":1712578500},{"token":"token-2","added_at":1712664960}]}`
-	encoded := base64.RawURLEncoding.EncodeToString([]byte(json))
+	encoded := V2EncodeString([]byte(json))
 	ts := NewTokenStoreFromString(encoded)
 
 	want := 2


### PR DESCRIPTION
### Overview

Add support for passing multiple time-stamped push notification tokens in
the `token` param as a base64url-encoded JSON object.

### Details

* Add struct TokenStore (TS), which stores a limited number of
  time-stamped push notification (PN) tokens in FIFO order
* Make FromString support a plain PN token (v1) or a base64url-encoded
  JSON TS object (v2)
* Treat v1 tokens as new, so old apps will stay working forever
* Implement Add / Find for completeness even though unused
* Add 1y cutoff after which v2 tokens are considered expired
* Send a PN for each unexpired token in the TS